### PR TITLE
Remove require 'rake'

### DIFF
--- a/hiera-simulator.gemspec
+++ b/hiera-simulator.gemspec
@@ -1,5 +1,3 @@
-require 'rake'
-
 Gem::Specification.new do |s|
   s.name        = 'hiera-simulator'
   s.version     = '0.0.1'


### PR DESCRIPTION
requireing rake means a full bundler run must previously have had rake
installed.

I was seeing this error:

```
==> Installing gem dependencies (Puppet 3.x)...
Fetching https://github.com/rhettg/hiera-simulator
Cloning into bare repository '/vagrant/vendor/gems/ruby/1.8/cache/bundler/git/hiera-simulator-6f29ab2d3d882b8e3a4b81e467f83f670cc4db37'...
remote: Counting objects: 85, done.
remote: Compressing objects: 100% (58/58), done.
remote: Total 85 (delta 13), reused 83 (delta 11), pack-reused 0
Unpacking objects: 100% (85/85), done.
Checking connectivity... done.
There was a LoadError while evaluating hiera-simulator.gemspec:
no such file to load -- rake from
  /vagrant/vendor/gems/ruby/1.8/bundler/gems/hiera-simulator-7aaa072d3ab3/hiera-simulator.gemspec:1
```
