### PR TITLE
Add more clear error messages from PuppetDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Here are the important ones:
 
 | Version | Notes |
 |---------|-------|
+| 0.2.2   | Raise error directly if PuppetDB responds with code 200 but has an error message |
 | 0.2.1   | Remove PuppetDB hiera backend support, add --[no-]stringify-facts command line option |
 | 0.2.0   | Add support for PuppetDB API v4 |
 | 0.1.0   | Initial release |

--- a/hiera-simulator.gemspec
+++ b/hiera-simulator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'hiera-simulator'
-  s.version     = '0.2.1'
+  s.version     = '0.2.2'
   s.authors     = 'Kevin Paulisse'
   s.date        = Time.now.strftime('%Y-%m-%d')
   s.homepage    = 'http://github.com/kpaulisse/hiera-simulator'

--- a/lib/hiera-simulator/fact_source/puppetdb.rb
+++ b/lib/hiera-simulator/fact_source/puppetdb.rb
@@ -40,6 +40,18 @@ module HieraSimulator
       def facts_common(uri)
         reply = response(uri)
 
+        # Check for an error from PuppetDB despite return code 200
+        if reply.is_a?(Hash) && reply.key?('error')
+          message = "Error from PuppetDB: #{reply['error']}"
+          raise HieraSimulator::FactLookupError, message
+        end
+
+        # Check for unexpected data - we expect an array
+        unless reply.is_a?(Array)
+          message = "Unexpected data from PuppetDB: Expected Array got #{reply.class}"
+          raise HieraSimulator::FactSourceError, message
+        end
+
         # Stringify facts if needed (old hiera, old PuppetDB)
         if @stringify_facts
           result = {}

--- a/spec/fixtures/puppetdb/error-response.json
+++ b/spec/fixtures/puppetdb/error-response.json
@@ -1,0 +1,1 @@
+{"error": "No information is known about node aldfkaslfkasdkf"}

--- a/spec/fixtures/puppetdb/unexpected-response.json
+++ b/spec/fixtures/puppetdb/unexpected-response.json
@@ -1,0 +1,1 @@
+{"this should have": "been an array"}

--- a/spec/hiera-simulator/fact_source/puppetdb_spec.rb
+++ b/spec/hiera-simulator/fact_source/puppetdb_spec.rb
@@ -21,6 +21,26 @@ describe HieraSimulator::FactSource::PuppetDB do
     end
   end
 
+  describe '#facts_common' do
+    it 'Should raise HieraSimulator::FactLookupError if PuppetDB returns error' do
+      filepath = HieraSimulator::Spec.gem_file('spec/fixtures/puppetdb/error-response.json')
+      testobj = HieraSimulator::FactSource::PuppetDB.new(@config, mock_puppetdb: filepath, puppetdb_api_version: 4)
+      expected_error_message = 'Error from PuppetDB: No information is known about node aldfkaslfkasdkf'
+      expect do
+        result = testobj.facts('aldfkaslfkasdkf')
+      end.to raise_error(HieraSimulator::FactLookupError, expected_error_message)
+    end
+
+    it 'Should raise HieraSimulator::FactLookupError if PuppetDB does not return array' do
+      filepath = HieraSimulator::Spec.gem_file('spec/fixtures/puppetdb/unexpected-response.json')
+      testobj = HieraSimulator::FactSource::PuppetDB.new(@config, mock_puppetdb: filepath, puppetdb_api_version: 4)
+      expected_error_message = 'Unexpected data from PuppetDB: Expected Array got Hash'
+      expect do
+        result = testobj.facts('aldfkaslfkasdkf')
+      end.to raise_error(HieraSimulator::FactSourceError, expected_error_message)
+    end
+  end
+
   describe '#facts' do
     it 'Should raise PuppetDBError if invalid PuppetDB API version is detected' do
       override = { puppetdb_api_version: -100 }


### PR DESCRIPTION
Previous message if a host was not found in PuppetDB API v4:

```
hiera-simulator-0.2.1/lib/hiera-simulator/fact_source/puppetdb.rb:56:in `[]': no implicit conversion of String into Integer (TypeError)
```

New error message:

```
PuppetDB: Error from PuppetDB: No information is known about node aldfkaslfkasdkf
```
