### PR TITLE
Avoid error unlinking file when lookup value was not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Here are the important ones:
 
 | Version | Notes |
 |---------|-------|
+| 0.2.3   | Resolve `No such file or directory @ unlink_internal` error unlinking hiera config file if value wasn't found |
 | 0.2.2   | Raise error directly if PuppetDB responds with code 200 but has an error message |
 | 0.2.1   | Remove PuppetDB hiera backend support, add --[no-]stringify-facts command line option |
 | 0.2.0   | Add support for PuppetDB API v4 |

--- a/hiera-simulator.gemspec
+++ b/hiera-simulator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'hiera-simulator'
-  s.version     = '0.2.2'
+  s.version     = '0.2.3'
   s.authors     = 'Kevin Paulisse'
   s.date        = Time.now.strftime('%Y-%m-%d')
   s.homepage    = 'http://github.com/kpaulisse/hiera-simulator'

--- a/lib/hiera-simulator/hieralookup.rb
+++ b/lib/hiera-simulator/hieralookup.rb
@@ -14,7 +14,7 @@ module HieraSimulator
       hiera = Hiera.new(config: hiera_tmp_config)
       Hiera.logger = options.fetch(:verbose, false) ? 'console' : 'noop'
       result = hiera.lookup(key, nil, facts, nil, options.fetch(:resolution_type, :priority))
-      File.unlink(hiera_tmp_config)
+      File.unlink(hiera_tmp_config) if File.file?(hiera_tmp_config)
       result
     end
 


### PR DESCRIPTION
Discovered that sometimes I would get this error if a value was not found:

```
.../puppet/vendor/gems/ruby/2.1.0/gems/hiera-simulator-0.2.2/lib/hiera-simulator/hieralookup.rb:17:in `unlink': No such file or directory @ unlink_internal - /var/folders/dw/.../T/hiera.yaml20160518-29371-t1d642 (Errno::ENOENT)
```

Add a specific test to make sure the file exists before trying to remove it.
